### PR TITLE
Move back to using xsd:duration instead of xsd:time in RTZ 1.1

### DIFF
--- a/SampleFiles/AllOptionalElements/RTZ1.1AllOptionalElementsAndAttributes.rtz
+++ b/SampleFiles/AllOptionalElements/RTZ1.1AllOptionalElementsAndAttributes.rtz
@@ -100,7 +100,7 @@
         <scheduleElement waypointId="43" speed="20.0" />
         <scheduleElement waypointId="4"  speed="20.0" />
         <scheduleElement waypointId="0"  speed="20.0" />
-        <scheduleElement waypointId="5"  speed="20.0" eta="2020-02-27T21:38:42z" stay="00:02:00" etd="2020-02-27T23:38:42z" Note="Wait 2hrs before going somewhere else" />
+        <scheduleElement waypointId="5"  speed="20.0" eta="2020-02-27T21:38:42z" stay="PT2H" etd="2020-02-27T23:38:42z" Note="Wait 2hrs before going somewhere else" />
       </manual>
       <calculated>
 		<scheduleElement waypointId="11" etd="2020-02-18T00:00:00z" />
@@ -118,8 +118,8 @@
 	<schedule id="996" name="Optimised schedule">
 		<calculated>
 			<scheduleElement waypointId="11" etd="2020-02-18T00:00:00z" windDirection="277" windSpeed="5.9"  currentSpeed="0.7" currentDirection="58" />
-			<scheduleElement waypointId="2"  eta="2020-02-18T00:04:22z" windDirection="165" windSpeed="27.5" currentSpeed="0.7" currentDirection="58" windLoss="0.1" waveLoss="0.1" totalLoss="0.2"  etdWindowBefore="00:01:30" etdWindowAfter="00:05:00" etaWindowBefore="00:01:10" etaWindowAfter="00:01:30"  speedWindow="0.10" rpm="600" pitch="1"  fuel="2567" relFuelSave="10" absFuelSave="5" />
-			<scheduleElement waypointId="43" eta="2020-02-25T17:36:25z" windDirection="165" windSpeed="27.5" currentSpeed="0.0" currentDirection="60" windLoss="0.9" waveLoss="1.9" totalLoss= "2.8" etdWindowBefore="09:30:11" etdWindowAfter="09:15:12" etaWindowBefore="09:15:13" etaWindowAfter="09:15:14"  speedWindow="3.15" rpm="642" pitch="13" fuel="1112567" relFuelSave="12549" absFuelSave="23134" />
+			<scheduleElement waypointId="2"  eta="2020-02-18T00:04:22z" windDirection="165" windSpeed="27.5" currentSpeed="0.7" currentDirection="58" windLoss="0.1" waveLoss="0.1" totalLoss="0.2"  etdWindowBefore="PT1M30S" etdWindowAfter="PT5M" etaWindowBefore="PT1M10S" etaWindowAfter="PT1M30S" speedWindow="0.10" rpm="600" pitch="1"  fuel="2567" relFuelSave="10" absFuelSave="5" />
+			<scheduleElement waypointId="43" eta="2020-02-25T17:36:25z" windDirection="165" windSpeed="27.5" currentSpeed="0.0" currentDirection="60" windLoss="0.9" waveLoss="1.9" totalLoss= "2.8" etdWindowBefore="PT9H30M11S" etdWindowAfter="PT9H" etaWindowBefore="PT555M" etaWindowAfter="PT555M59S"  speedWindow="3.15" rpm="642" pitch="13" fuel="1112567" relFuelSave="12549" absFuelSave="23134" />
 			<scheduleElement waypointId="4"  eta="2020-02-27T14:17:34z" Note="out of forecast range" />      
 			<scheduleElement waypointId="0"  eta="2020-02-27T19:26:51z" Note="out of forecast range" />      
 			<scheduleElement waypointId="5"  eta="2020-02-27T21:38:42z" Note="out of forecast range" />        

--- a/src/rtz/rtz/Properties/RTZ Schema version 1_1.xsd
+++ b/src/rtz/rtz/Properties/RTZ Schema version 1_1.xsd
@@ -710,14 +710,14 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="etdWindowBefore" type="xsd:time">
+		<xsd:attribute name="etdWindowBefore" type="xsd:duration">
 			<xsd:annotation>
 				<xsd:documentation>
           The maximum value of time interval prior to the ETD used to adjust the ETD to get the earliest probable date/time.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="etdWindowAfter" type="xsd:time">
+		<xsd:attribute name="etdWindowAfter" type="xsd:duration">
 			<xsd:annotation>
 				<xsd:documentation>
           The maximum value of time interval after the ETD used to adjust the ETD to get the latest probable date/time.
@@ -731,21 +731,21 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="etaWindowBefore" type="xsd:time">
+		<xsd:attribute name="etaWindowBefore" type="xsd:duration">
 			<xsd:annotation>
 				<xsd:documentation>
           The maximum value of time interval prior to the ETA used to adjust the ETA to get the earliest probable date/time.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="etaWindowAfter" type="xsd:time">
+		<xsd:attribute name="etaWindowAfter" type="xsd:duration">
 			<xsd:annotation>
 				<xsd:documentation>
           The maximum value of time interval after the ETA used to adjust the ETA to get the latest probable date/time.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="stay" type="xsd:time">
+		<xsd:attribute name="stay" type="xsd:duration">
 			<xsd:annotation>
 				<xsd:documentation>Stay time on WP.</xsd:documentation>
 			</xsd:annotation>


### PR DESCRIPTION
Move back to using xsd:duration instead of xsd:time in RTZ 1.1 after discussions around it. 